### PR TITLE
Correctly convert arguments

### DIFF
--- a/src/bufferize.js
+++ b/src/bufferize.js
@@ -1,0 +1,10 @@
+function Bufferize (result){
+  if (result instanceof ArrayBuffer)
+    result = new Uint8Array(result);
+  if (result instanceof Uint8Array)
+    result = new Buffer(result);
+
+  return result;
+}
+
+module.exports = Bufferize;

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 var Browser = require("./use_node.js")
 var OPS = ["generateKey", "importKey", "exportKey", "sign", "verify", "encrypt", "decrypt", "digest", "deriveKey", "deriveBits"]
 var nonce = require("crypto").randomBytes(64).toString("hex")
+var Bufferize = require('./bufferize')
 global.FORGE = require("./forgeless.js")
 global.Promise =  require("polyfill-promise")
 var Subtle = {}
@@ -25,14 +26,6 @@ function makeArgArray (args){
   return ar;
 }
 
-function Bufferize (result){
-  if (result instanceof ArrayBuffer)
-    result = new Uint8Array(result);
-  if (result instanceof Uint8Array)
-    result = new Buffer(result);
-
-  return result;
-}
 function makeRoutine(routine){
   return function(){
     var routineArgs = makeArgArray(arguments)

--- a/src/node/algorithms/AES-GCM.js
+++ b/src/node/algorithms/AES-GCM.js
@@ -1,5 +1,6 @@
 var sjcl      = require("sjcl")
   , Algorithm = require("./abstract")("AES-GCM")
+  , Bufferize = require('./../../bufferize')
   , AES       = require("./shared/AES")
   , secret = Algorithm.types.secret.usage
 
@@ -11,8 +12,13 @@ secret.decrypt = createDecrypt;
 module.exports = Algorithm;
 
 function getParams(alg, data){
-  return { iv   : sjcl.codec.hex.toBits(alg.iv.toString('hex'))
-         , add  : sjcl.codec.hex.toBits(alg.additionalData.toString('hex'))
+  var iv = Bufferize(alg.iv);
+  var additionalData = alg.additionalData ? Bufferize(alg.additionalData) : new Buffer([]);
+
+  data = data ? Bufferize(data) : new Buffer([]);
+
+  return { iv   : sjcl.codec.hex.toBits(iv.toString('hex'))
+         , add  : sjcl.codec.hex.toBits(additionalData.toString('hex'))
          , data : sjcl.codec.hex.toBits(data.toString('hex'))
          };
 }


### PR DESCRIPTION
Those arguments have to be `Buffer`s for `toString('hex')` to work correctly. This pull request assures this.
