### PR TITLE
Add support for SHA-1 digest

### DIFF
--- a/src/node/digest.js
+++ b/src/node/digest.js
@@ -1,6 +1,7 @@
 var forge = require("node-forge")
 var subtleToForge = {
-  "SHA-256" : "sha256"
+  "SHA-256" : "sha256",
+  "SHA-1"   : "sha1"
 }
 
 var digest = function digest(alg, data){


### PR DESCRIPTION
Forge has support for this algorithm:
https://github.com/digitalbazaar/forge/blob/master/js/sha1.js

There are others that can probably be added as well, I just only needed/tested SHA-1.
