### PR TITLE
Accept DOMString AlgorithmIdentifier in digest

### DIFF
--- a/src/node/digest.js
+++ b/src/node/digest.js
@@ -4,10 +4,11 @@ var subtleToForge = {
 }
 
 var digest = function digest(alg, data){
-  if (!subtleToForge[alg.name])
+  var name = (typeof alg === 'object') ? alg.name : alg
+  if (!subtleToForge[name])
     return Promise.reject("unsupported hashing algorithm")
   else{
-    var md = forge.md[subtleToForge[alg.name]].create()
+    var md = forge.md[subtleToForge[name]].create()
     md.update(data.toString("binary"))
 
     return new Buffer(md.digest().bytes(), "binary")


### PR DESCRIPTION
According to the spec, an `AlgorithmIdenfitier` can also be specified as a `DOMString`:
https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#dfn-AlgorithmIdentifier

There may be other areas where a similar change could be made.
